### PR TITLE
prevent duplicate arguments in aws-curl

### DIFF
--- a/bin/.bin/aws-curl
+++ b/bin/.bin/aws-curl
@@ -24,7 +24,17 @@ provider2="amz"
 verbose=""
 curl_args=()
 
+declare -A seen=()
+check_duplicate_arg() {
+    local arg=$1
+    if [[ ${seen[$arg]} ]]; then
+        echo "Error: Argument '$arg' specified multiple times" && usage 1
+    fi
+    seen[$arg]=1
+}
+
 while (($#)); do
+    check_duplicate_arg "$1"
     case "$1" in
         --region?(=*)|-r?(=*))
             region=$(echo "$1" | cut -s -d= -f2-)


### PR DESCRIPTION
I accidentally used it as `~/aws_curl.bash -u --region=us-east-1 --service=iam --unsigned-payload -- https://some-host.com -v`

note the sneaky `-u` in the beginning, which is added in addition to `--unsigned-payload` . 

Then it took me a while to figure out why I see twice the UNSIGNED_PAYLOAD header. This will prevent such user-fault cases.